### PR TITLE
Add ActiveAdmin + JSON API smoke specs

### DIFF
--- a/spec/requests/admin_smoke_spec.rb
+++ b/spec/requests/admin_smoke_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+# Smoke coverage for ActiveAdmin — the app's largest untested surface.
+# AA failures (bad Ransack filters, arbre/formtastic breakage) surface at
+# request time, not boot, so a green model suite says nothing about them.
+# These specs render every admin index for a signed-in admin and exercise the
+# Ransack query path that powers AA filters. They are the automated guard for
+# the Ransack 4 allowlist change coming in a later upgrade stage.
+RSpec.describe "ActiveAdmin smoke", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  before { sign_in create(:admin_user) }
+
+  # Every registered admin index should render for a signed-in admin.
+  %w[
+    /admin
+    /admin/dashboard
+    /admin/admin_users
+    /admin/comments
+    /admin/league_tournaments
+    /admin/rosters
+    /admin/teams
+    /admin/tournaments
+  ].each do |path|
+    it "GET #{path} returns 200" do
+      get path
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  # Applying a filter builds a Ransack query; this is the surface that breaks
+  # silently at query time when models lack ransackable allowlists (Ransack 4).
+  it "applies a Ransack filter on an index without error" do
+    create(:team)
+    get "/admin/teams", params: { q: { id_eq: Team.first.id } }
+    expect(response).to have_http_status(:ok)
+  end
+end

--- a/spec/requests/api/v1/rosters_spec.rb
+++ b/spec/requests/api/v1/rosters_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+# Smoke coverage for the JSON:API endpoint + jsonapi-rails serializers, which
+# have zero coverage despite crossing major Rails/gem versions in this upgrade.
+# One case proves the empty-collection plumbing (route -> controller ->
+# jsonapi rendering); one proves an actual roster serializes through
+# SerializableRoster. Roster#score reaches an external score parser over the
+# network, so it is stubbed here to keep the smoke test hermetic.
+RSpec.describe "Api::V1::Rosters", type: :request do
+  it "returns an empty JSON:API collection when a tournament has no rosters" do
+    league_tournament = create(:league_tournament)
+
+    get "/api/v1/rosters", params: { league_tournament_id: league_tournament.id }
+
+    expect(response).to have_http_status(:ok)
+    expect(response.content_type).to match(%r{application/vnd\.api\+json})
+    expect(JSON.parse(response.body)["data"]).to eq([])
+  end
+
+  it "serializes a roster's score and team name for the tournament" do
+    league_tournament = create(:league_tournament)
+    user = create(:user)
+    team = create(:team, user: user)
+    create(:roster, team: team, league_tournament: league_tournament)
+    # Roster#score hits an external score parser; stub it for a hermetic smoke.
+    allow_any_instance_of(Roster).to receive(:score).and_return(42)
+
+    get "/api/v1/rosters", params: { league_tournament_id: league_tournament.id }
+
+    expect(response).to have_http_status(:ok)
+    body = JSON.parse(response.body)
+    expect(body["data"].size).to eq(1)
+    expect(body["data"].first["type"]).to eq("roster")
+    attributes = body["data"].first["attributes"]
+    expect(attributes["score"]).to eq(42)
+    expect(attributes["name"]).to eq(user.name)
+  end
+end


### PR DESCRIPTION
Adds automated smoke coverage for the app's two biggest test blind spots, per `UPGRADE_PLAN.md`'s "cheap insurance to add before Stage 5." Kept separate from the Rails 6 upgrade PR (#91) so that stays a pure version bump.

Both specs are green on **Rails 5.2** (this branch's baseline: 35 examples, 0 failures) and are designed to guard these surfaces *through* the staged upgrade.

## What's covered
- **`spec/requests/admin_smoke_spec.rb`** — signs in an admin and asserts all 8 ActiveAdmin index pages render `200`, plus one Ransack-filtered index. ActiveAdmin has zero automated coverage today and its failures (bad filters, arbre/formtastic breakage) surface at **request/query time, not boot** — a green model suite says nothing about them. This is the automated guard for the **Ransack 4 allowlist** change coming at Stage 5, and it automates the manual AA smoke run during the Rails 6 bump.
- **`spec/requests/api/v1/rosters_spec.rb`** — one empty-collection case (route → controller → jsonapi-rails rendering) and one serialized roster through `SerializableRoster`. `jsonapi-rails` + the serializers had no coverage despite crossing major Rails versions.

## Notes
- `Roster#score` reaches an external score parser over HTTP, so it's stubbed to keep the API smoke hermetic (no VCR cassette needed).
- No app/config changes — additive test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)