### PR TITLE
Stage 2 (Gate B): flip config.load_defaults to 6.0 (Zeitwerk on)

### DIFF
--- a/app/models/roster_player.rb
+++ b/app/models/roster_player.rb
@@ -37,6 +37,6 @@ class RosterPlayer < ApplicationRecord
   end
 
   def roster_player_parser
-    @roster_player_parser ||= RosterPlayerParser.new(league_tournament.external_id, external_id, league_tournament.completed)
+    @roster_player_parser ||= RosterPlayerThruParser.new(league_tournament.external_id, external_id, league_tournament.completed)
   end
 end

--- a/app/models/roster_player_thru_parser.rb
+++ b/app/models/roster_player_thru_parser.rb
@@ -1,4 +1,4 @@
-class RosterPlayerParser
+class RosterPlayerThruParser
 
   def initialize tournament_external_id, athlete_external_id, completed
     @tournament_external_id = tournament_external_id

--- a/config/application.rb
+++ b/config/application.rb
@@ -9,7 +9,7 @@ Bundler.require(*Rails.groups)
 module Augusta
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 5.1
+    config.load_defaults 6.0
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers


### PR DESCRIPTION
Completes **Stage 2** of the staged Ruby/Rails upgrade. Gate A already moved the app to Rails 6.0.6.1 (Ruby 2.7.8) with `config.load_defaults` held at 5.1; this flips it to **6.0**, activating all Rails 6.0 framework defaults — most notably **Zeitwerk** autoloading.

## Changes
- `config/application.rb`: `config.load_defaults 5.1` → `6.0`.
- Zeitwerk fix: `bin/rails zeitwerk:check` surfaced one classic-loader constant/filename mismatch — `app/models/roster_player_thru_parser.rb` defined `RosterPlayerParser`. Renamed the class to `RosterPlayerThruParser` (matches the filename and its sibling `RosterPlayerScoreParser`) and updated the single call site in `RosterPlayer#roster_player_parser`.

## Verification
- `bin/rails zeitwerk:check` → **All is good!**
- RSpec **35 examples, 0 failures**.
- Audited the now-active 6.0 defaults: `return_only_media_type_on_content_type` stays **false** at 6.0, so the `content_type` deprecation in `api/v1/rosters_controller.rb` stays dormant until **Stage 3** (as planned). No app-specific overrides needed; `new_framework_defaults_6_0.rb` is correctly inert.

## Discipline
- One PR per stage, base `master`, for clean rollback.
- No Ruby bump in this stage (Ruby stays 2.7.8).

Next up: **Stage 3** — Rails 6.0 → 6.1 (address the `content_type` → `#media_type` deprecation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)